### PR TITLE
feat: add basic jobs api structure with wanted testing apis JDY-22

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -23,6 +23,7 @@ from server.api.credentials.users import get_user_comments
 from server.api.bulletin.likes import post_like
 from server.api.bulletin.likes import delete_like
 from server.api.bulletin.likes import like_or_not
+
 from server.api.pocha.info import get_pocha
 from server.api.pocha.info import get_pocha_menu
 from server.api.pocha.order import get_user_orders
@@ -36,6 +37,11 @@ from server.api.pocha.dashboard import put_order_item_status
 from server.api.pocha.dashboard import put_menu_stock
 from server.api.pocha.payment import reserve_cart_stock
 from server.api.pocha.payment import pay_success_fail
+from server.api.pocha.notification import register_token
+
 from server.api.images.presigned_url import presigned_url_for_post
 from server.api.images.presigned_url import presigned_url_for_get
-from server.api.pocha.notification import register_token
+
+# JOBS APIS -----------------------------------------------------------
+from server.api.jobs.index import get_jobs_info
+from server.api.jobs.third_party.wanted.index import get_job_categories

--- a/server/api/jobs/crawler/index.py
+++ b/server/api/jobs/crawler/index.py
@@ -1,0 +1,1 @@
+# TODO: implement crawler job source

--- a/server/api/jobs/index.py
+++ b/server/api/jobs/index.py
@@ -1,0 +1,43 @@
+import flask
+import server
+
+import server.api.jobs.third_party.wanted.wanted as wanted
+
+
+@server.application.route("/api/v2/jobs/", methods=["GET"])
+def get_jobs_info():
+    source = flask.request.args.get("from", "third-party")
+    if source == "third-party":
+        # wanted api - internships
+        # data, next_url, status_code = wanted.fetch_wanted_internships(
+        #     category=flask.request.args.get('category'),
+        #     offset=flask.request.args.get('offset', 0),
+        #     limit=flask.request.args.get('limit', 20)
+        # )
+
+        # approach 1: fetch all internships with employment_type == 'intern'
+        # NOTE: this approach works, but slow because it fetches multiple pages
+        response = wanted.fetch_all_internships_with_employment_type_check(
+            category=flask.request.args.get("category"),
+            offset=flask.request.args.get("offset", 0),
+            limit=flask.request.args.get("limit", 20),
+        )
+
+        # approach 2: fetch all internships with search position
+        # NOTE: this approach is not ideal because category is not used
+        # response = wanted.fetch_all_internships_with_search_position(
+        #     category=flask.request.args.get("category"),
+        #     offset=flask.request.args.get("offset", 0),
+        #     limit=flask.request.args.get("limit", 20),
+        # )
+
+        return flask.jsonify(response), 200
+    elif source == "crawler":
+        # Placeholder for crawler logic
+        return flask.jsonify(
+            {"message": "Crawler job source not implemented yet."}
+        ), 501
+    else:
+        return flask.jsonify(
+            {"error": f"Job source '{source}' is not supported."}
+        ), 400

--- a/server/api/jobs/third_party/wanted/constants.py
+++ b/server/api/jobs/third_party/wanted/constants.py
@@ -1,0 +1,31 @@
+import os
+
+REQUEST_TIMEOUT = 10  # seconds
+
+WANTED_CLIENT_ID = os.environ.get('WANTED_API_CLIENT_ID')
+WANTED_CLIENT_SECRET = os.environ.get('WANTED_API_CLIENT_SECRET')
+WANTED_BASE_URL = 'https://openapi.wanted.jobs/v1'
+WANTED_BASE_URL_V2 = 'https://openapi.wanted.jobs/v2'
+
+WANTED_CATEGORY_MAP = {
+    'developer': 518,  # 개발
+    'business': 507,   # 경영·비즈니스
+    'marketing': 523,  # 마케팅·광고
+    'design': 511,     # 디자인
+    'sales': 530,      # 영업
+    'customer_service': 510,  # 고객서비스·리테일
+    'hr': 517,         # HR
+    'finance': 508,    # 금융
+    'media': 524,      # 미디어
+    'engineering': 513, # 엔지니어링·설계
+    'manufacturing': 522, # 제조·생산
+    'logistics': 532,  # 물류·무역
+    'game': 959,       # 게임 제작
+    'security': 10566, # 정보보호
+    'medical': 515,    # 의료·제약·바이오
+    'education': 10101, # 교육
+    'legal': 521,      # 법률·법집행기관
+    'food': 10057,     # 식·음료
+    'construction': 509, # 건설·시설
+    'public': 514,     # 공공·복지
+}

--- a/server/api/jobs/third_party/wanted/helpers.py
+++ b/server/api/jobs/third_party/wanted/helpers.py
@@ -1,0 +1,10 @@
+import server.api.jobs.third_party.wanted.constants as constants
+
+
+def get_wanted_headers():
+    return {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'wanted-client-id': constants.WANTED_CLIENT_ID,
+        'wanted-client-secret': constants.WANTED_CLIENT_SECRET
+    }

--- a/server/api/jobs/third_party/wanted/index.py
+++ b/server/api/jobs/third_party/wanted/index.py
@@ -1,0 +1,17 @@
+import requests
+import flask
+import server.api.jobs.third_party.wanted.constants as constants
+import server.api.jobs.third_party.wanted.helpers as helpers
+import server
+
+@server.application.route('/api/v2/jobs/categories/', methods=['GET'])
+def get_job_categories():
+    endpoint = '/tags/categories'
+    url = constants.WANTED_BASE_URL + endpoint
+    headers = helpers.get_wanted_headers()
+    try:
+        resp = requests.get(url, headers=headers, timeout=constants.REQUEST_TIMEOUT)
+        resp.raise_for_status()
+        return flask.jsonify(resp.json()), resp.status_code
+    except requests.RequestException as e:
+        return flask.jsonify({'error': str(e)}), 500

--- a/server/api/jobs/third_party/wanted/wanted.py
+++ b/server/api/jobs/third_party/wanted/wanted.py
@@ -1,0 +1,160 @@
+import requests
+import server.api.jobs.third_party.wanted.constants as constants
+import server.api.jobs.third_party.wanted.helpers as helpers
+import urllib.parse as urlparse
+
+
+def fetch_wanted_jobs(params=None):
+    """
+    General function to call the Wanted jobs API with arbitrary params.
+    """
+    endpoint = "/jobs"
+    url = constants.WANTED_BASE_URL_V2 + endpoint
+    headers = helpers.get_wanted_headers()
+    if params is None:
+        params = {}
+    resp = requests.get(
+        url, headers=headers, params=params, timeout=constants.REQUEST_TIMEOUT
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    next_url = data["links"]["next"]
+    return data, next_url, resp.status_code
+
+
+def fetch_wanted_internships(
+    category=None, offset=0, limit=20, additional_params=None
+):
+    """
+    Fetch internship and entry-level jobs from Wanted.
+    """
+    params = {
+        "offset": offset,
+        "limit": limit,
+        "years": [0, 2],  # intern, entry level
+        **additional_params,
+    }
+    if category:
+        params["category_tag"] = constants.WANTED_CATEGORY_MAP[category]
+    return fetch_wanted_jobs(params)
+
+
+def fetch_all_internships_with_employment_type_check(
+    category=None, offset=0, limit=20, max_pages=10
+):
+    """
+    Fetch all internship jobs from Wanted by paginating and filtering by employment_type == 'intern'.
+    Returns a dict with 'data' (list of jobs) and 'links' (pagination info).
+    Limits the number of pages fetched to max_pages to avoid long runtimes.
+    """
+    all_internships = []
+    next_url = None
+    page_count = 0
+    while True:
+        if page_count >= max_pages:
+            break
+        data, next_url, status_code = fetch_wanted_internships(
+            category=category,
+            offset=offset,
+            limit=limit,
+            additional_params={"locations": ["seoul", "gyeonggi"]},
+        )
+        jobs = (
+            data.get("data", data.get("results", []))
+            if isinstance(data, dict)
+            else []
+        )
+        # Filter only internships
+        internships = [
+            job for job in jobs if job.get("employment_type") == "intern"
+        ]
+        all_internships.extend(internships)
+        # Pagination: break if no more data
+        if not next_url or not jobs:
+            break
+        # Extract next offset from next_url if available
+        parsed = urlparse.urlparse(next_url)
+        params = urlparse.parse_qs(parsed.query)
+        try:
+            offset = int(params.get("offset", [offset + limit])[0])
+        except Exception:
+            offset += limit
+        page_count += 1
+    # Compose response in the new format
+    response = {
+        "data": all_internships,
+        "links": {
+            "next": next_url,
+            "prev": None,  # prev can be implemented if needed
+        },
+    }
+    return response
+
+
+def fetch_wanted_internships_with_search_position(
+    category=None, offset=0, limit=20, max_pages=10
+):
+    """
+    Fetch internships from Wanted using /v1/search/position with query='인턴' and years=[0,2].
+    """
+    endpoint = "/search/position"
+    url = constants.WANTED_BASE_URL + endpoint
+    headers = helpers.get_wanted_headers()
+    params = {
+        "query": "인턴",
+        "offset": offset,
+        "limit": limit,
+    }
+    if category:
+        params["category_tag"] = constants.WANTED_CATEGORY_MAP[category]
+    resp = requests.get(
+        url, headers=headers, params=params, timeout=constants.REQUEST_TIMEOUT
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    next_url = data.get("links", {}).get("next")
+    # Return positions as the main data
+    return data.get("positions", []), next_url, resp.status_code
+
+
+def fetch_all_internships_with_search_position(
+    category=None, offset=0, limit=20, max_pages=10
+):
+    """
+    Fetch all internship jobs from Wanted using /v1/search/position by paginating.
+    Returns a dict with 'data' (list of positions) and 'links' (pagination info).
+    Limits the number of pages fetched to max_pages to avoid long runtimes.
+    """
+    all_positions = []
+    next_url = None
+    page_count = 0
+    while True:
+        if page_count >= max_pages:
+            break
+        positions, next_url, status_code = (
+            fetch_wanted_internships_with_search_position(
+                category=category,
+                offset=offset,
+                limit=limit,
+            )
+        )
+        # positions is already a list of jobs
+        all_positions.extend(positions)
+        if not next_url or not positions:
+            break
+        # Extract next offset from next_url if available
+        parsed = urlparse.urlparse(next_url)
+        params = urlparse.parse_qs(parsed.query)
+        try:
+            offset = int(params.get("offset", [offset + limit])[0])
+        except Exception:
+            offset += limit
+        page_count += 1
+    response = {
+        "data": all_positions,
+        "links": {
+            "next": next_url,
+            "prev": None,
+        },
+    }
+    return response


### PR DESCRIPTION
# Description

- add basic jobs api structure (jobs folder)
- divide a folder into two subfolders: third_party and crawler
- `index.py` is responsible for defining exposed endpoints 
- add Wanted API call functions with a very basic implementation (need to improve further)
- able to fetch internship positions in different categories
NOTE: to try out code in local env, need to install requests python pkg and add env variables called `WANTED_API_CLIENT_ID` and `WANTED_API_CLIENT_SECRET` in `.env` file.

# Screenshot

![스크린샷 2025-06-29 오후 6 48 12](https://github.com/user-attachments/assets/483e1b0d-f590-4a51-91cf-b0c256803396)
