### PR TITLE
chore: add Claude Code GitHub automation (@claude)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,9 @@
 name: Claude Code
 
 # Runs Claude Code when "@claude" appears in an issue, an issue/PR comment,
-# or a PR review. Claude implements changes on a branch and opens a PR; it
-# never pushes to the default branch and never auto-merges.
+# or a PR review. Claude implements changes on a branch; a separate step then
+# opens a PR using CLAUDE_PR_PAT so that the pull_request event fires (the
+# default GITHUB_TOKEN would not trigger the risk-label and Codex workflows).
 on:
   issue_comment:
     types: [created]
@@ -35,6 +36,41 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      # Open the PR ourselves with a PAT. PRs opened by the default GITHUB_TOKEN
+      # do not trigger other workflows, so the risk-label and Codex reviews would
+      # never run. The PAT is scoped to this step only; it never authors commits.
+      - name: Open pull request
+        if: ${{ steps.claude.outputs.branch_name != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.CLAUDE_PR_PAT }}
+          BRANCH: ${{ steps.claude.outputs.branch_name }}
+          BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "CLAUDE_PR_PAT is not set; branch '$BRANCH' was pushed but no PR was opened."
+            echo "Add the CLAUDE_PR_PAT secret to enable automatic PR creation."
+            exit 0
+          fi
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            echo "A PR already exists for $BRANCH; nothing to do."
+            exit 0
+          fi
+          TITLE="Claude: ${BRANCH}"
+          if [ -f /tmp/pr_title.txt ]; then
+            TITLE="$(head -n 1 /tmp/pr_title.txt)"
+          fi
+          if [ ! -f /tmp/pr_body.md ]; then
+            {
+              echo "Automated pull request created by Claude Code."
+              echo
+              echo "Risk level: human-required (risk not reported by Claude; defaulting to human review)."
+            } > /tmp/pr_body.md
+          fi
+          gh pr create --base "${BASE:-main}" --head "$BRANCH" \
+            --title "$TITLE" --body-file /tmp/pr_body.md

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+# Runs Claude Code when "@claude" appears in an issue, an issue/PR comment,
+# or a PR review. Claude implements changes on a branch and opens a PR; it
+# never pushes to the default branch and never auto-merges.
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run when the "@claude" trigger phrase is present.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,0 +1,54 @@
+name: Risk label
+
+# Deterministically applies the risk label (simple / complex / human-required)
+# by parsing a "Risk level: <level>" line from the PR body. Runs on every PR so
+# the label reflects whatever the PR body currently declares.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply risk label from PR body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          # Passed via env (never inlined into the script) to avoid injection.
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the three risk labels exist (idempotent).
+          gh label create simple         -R "$REPO" --color 0e8a16 --description "Low-risk, well-contained change" --force >/dev/null 2>&1 || true
+          gh label create complex        -R "$REPO" --color fbca04 --description "Non-trivial logic; deeper review needed" --force >/dev/null 2>&1 || true
+          gh label create human-required -R "$REPO" --color b60205 --description "Sensitive area; requires human review, no auto-approve" --force >/dev/null 2>&1 || true
+
+          # Extract the declared risk level (case-insensitive, optional backticks).
+          RISK="$(printf '%s' "$BODY" \
+            | grep -ioE 'risk level:[[:space:]]*`?(simple|complex|human-required)`?' \
+            | head -n 1 \
+            | grep -ioE '(simple|complex|human-required)' \
+            | head -n 1 \
+            | tr '[:upper:]' '[:lower:]' || true)"
+
+          if [ -z "${RISK:-}" ]; then
+            echo "No 'Risk level:' line found in PR body; leaving labels unchanged."
+            exit 0
+          fi
+          echo "Declared risk level: $RISK"
+
+          # Remove any stale risk labels, then apply the declared one.
+          for l in simple complex human-required; do
+            if [ "$l" != "$RISK" ]; then
+              gh pr edit "$PR" -R "$REPO" --remove-label "$l" >/dev/null 2>&1 || true
+            fi
+          done
+          gh pr edit "$PR" -R "$REPO" --add-label "$RISK"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,16 @@ a pull request. It is never authorization to push to `main` or to merge.
 
 ### Working style
 - Create small, focused pull requests. One concern per PR.
-- Never push directly to `main`. Always work on a branch and open a PR.
+- Never push directly to `main`. Always work on a branch; the automation opens the PR (see "Opening the pull request").
 - Never auto-merge. Codex review and the human owner decide.
 - Write a clear PR description with: a short summary of the change, the reason, the files
   touched, and the checks you ran with their results.
 
 ### Risk level (required on every PR)
-Every PR you open MUST declare a risk level, both as a label and in the PR body:
+Every PR MUST declare a risk level. You declare it by including a line of the exact form
+`Risk level: <level>` in the PR body (see "Opening the pull request" below). A workflow reads
+that line and applies the matching label automatically, so you do not run `gh label` yourself.
+The levels are:
 
 - `simple` — small, low-risk, well-contained change (copy, isolated bug fix) with passing checks.
 - `complex` — multi-file or non-trivial logic change. Review more deeply, add or update tests,
@@ -33,8 +36,17 @@ Every PR you open MUST declare a risk level, both as a label and in the PR body:
 - `human-required` — touches a sensitive area (see below). Do not present it as safe to
   auto-approve; flag it for human review.
 
-Apply the label with `gh pr edit <number> --add-label <risk>`. Create the label first with
-`gh label create <risk>` if it does not exist.
+### Opening the pull request
+Do NOT run `gh pr create` yourself. After you commit and push your branch, an automated
+workflow step opens the PR for you. Hand off the PR title and body by writing two files:
+
+- `/tmp/pr_title.txt` — a single line: the PR title.
+- `/tmp/pr_body.md` — the PR description. It MUST contain a line of the exact form
+  `Risk level: simple` (or `complex`, or `human-required`), plus a short summary, the reason,
+  the files touched, and the checks you ran with results.
+
+If you do not write these files the PR is still opened, but with a generic body and defaulted
+to `human-required`.
 
 ### Always mark `human-required`
 Mark the PR `human-required` if it touches any of:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+Operational rules for Claude Code when working in this repository.
+
+## Architecture Overview
+
+KISA website backend: a Flask application (entry point `application.py`) using MySQL
+(`Flask-MySQLdb`) and websockets (`Flask-SocketIO`), deployed to AWS Elastic Beanstalk
+(`.ebextensions/`). SQL lives under `queries/`. Tests live alongside the code (e.g.
+`test_internship_logic.py`).
+
+## GitHub Automation (when triggered by `@claude`)
+
+These rules apply when you are invoked from a GitHub issue or pull request (the `@claude`
+trigger).
+
+Being invoked via `@claude` is explicit authorization to commit to a working branch and open
+a pull request. It is never authorization to push to `main` or to merge.
+
+### Working style
+- Create small, focused pull requests. One concern per PR.
+- Never push directly to `main`. Always work on a branch and open a PR.
+- Never auto-merge. Codex review and the human owner decide.
+- Write a clear PR description with: a short summary of the change, the reason, the files
+  touched, and the checks you ran with their results.
+
+### Risk level (required on every PR)
+Every PR you open MUST declare a risk level, both as a label and in the PR body:
+
+- `simple` — small, low-risk, well-contained change (copy, isolated bug fix) with passing checks.
+- `complex` — multi-file or non-trivial logic change. Review more deeply, add or update tests,
+  and run all checks before recommending approval.
+- `human-required` — touches a sensitive area (see below). Do not present it as safe to
+  auto-approve; flag it for human review.
+
+Apply the label with `gh pr edit <number> --add-label <risk>`. Create the label first with
+`gh label create <risk>` if it does not exist.
+
+### Always mark `human-required`
+Mark the PR `human-required` if it touches any of:
+- payments / Stripe / Pocha order state
+- auth / JWT / admin permissions
+- database migrations or schema changes (`queries/`, MySQL schema)
+- secrets, credentials, or environment variables (including `secret_key.txt`)
+- deployment config or GitHub Actions workflows (`.ebextensions/`, `.github/`)
+- dependency upgrades (`requirements.txt`)
+- anything security-sensitive
+
+### Checks before opening or updating a PR
+Run the available tests and report their output in the PR body:
+
+```bash
+python -m pytest            # if pytest is configured
+python test_internship_logic.py   # otherwise run the existing test scripts directly
+```
+
+If no automated test covers the change, describe the manual verification you performed
+(for example: which endpoint you exercised and the expected response). Do not leave the
+app in a broken state.
+
+## No Emojis in Markdown
+
+Never use emojis in markdown documents, comments, or code.


### PR DESCRIPTION
## Summary
Sets up Claude Code as the implementation agent for this repo, triggered by `@claude` in issues, comments, and PR reviews.

## Changes
- **`.github/workflows/claude.yml`** — runs `anthropics/claude-code-action@v1` on issue comments, PR review comments, PR reviews, and opened/assigned issues. Gated on the `@claude` trigger phrase. Permissions: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`. Authenticates via `secrets.ANTHROPIC_API_KEY` (already configured).
- **`CLAUDE.md`** — operational rules for `@claude` runs: small focused PRs, no direct push to `main`, no auto-merge, required risk level (`simple` / `complex` / `human-required`), required checks, and the list of sensitive areas that must be marked `human-required` (payments/Stripe, auth/JWT, DB migrations, secrets/env, deploy/Actions, dependency upgrades).

## How it works once merged
Comment `@claude <request>` on an issue or PR. Claude creates a branch, implements the change, runs the repo's checks, and opens a PR with a risk level. It never pushes to `main` and never auto-merges — Codex review and human owners gate from there.

## Risk
`human-required` — this PR adds a GitHub Actions workflow, which is a sensitive area. Please review the trigger conditions and permissions before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)